### PR TITLE
Fix wrong transition logic in affirm_controller

### DIFF
--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -59,7 +59,7 @@ module Spree
       })
 
       # transition to confirm or complete
-      while order.next; end
+      order.next
 
       redirect_to checkout_path
     end


### PR DESCRIPTION
The plugin loops over all possible future transitions and executes all of them,
without regard to whether they should be executed.