### PR TITLE
[ec-2521] migrate from charges api to transactions api

### DIFF
--- a/lib/spree_affirm/version.rb
+++ b/lib/spree_affirm/version.rb
@@ -1,3 +1,3 @@
 module SpreeAffirm
-  VERSION = "0.2.24"
+  VERSION = "0.2.25"
 end


### PR DESCRIPTION
- update `/charges` endpoint to `/transactions` endpoint
- update relevant response handling
- update relevant arguments